### PR TITLE
IDisposable tuning

### DIFF
--- a/Lib/Data/Invoice.Partial.cs
+++ b/Lib/Data/Invoice.Partial.cs
@@ -61,10 +61,18 @@ namespace HlidacStatu.Lib.Data
             bool dispose = fc == null;
             if (dispose)
                 fc = new Lib.Data.DbEntities();
-            this.items = fc.InvoiceItems.Where(m => m.ID_Invoice == this.ID).ToList();
 
-            if (dispose)
-                fc.Dispose();
+			try
+			{
+				this.items = fc.InvoiceItems.Where(m => m.ID_Invoice == this.ID).ToList();
+			}
+			finally
+			{
+				if (dispose)
+				{
+					fc?.Dispose();
+				}
+			}
 
             return this.items;
         }

--- a/Util.WebShot/Chrome.cs
+++ b/Util.WebShot/Chrome.cs
@@ -123,7 +123,7 @@ namespace HlidacStatu.Util.WebShot
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
             // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
+            GC.SuppressFinalize(this);
         }
         #endregion
 

--- a/Util.WebShot/Worker.cs
+++ b/Util.WebShot/Worker.cs
@@ -84,9 +84,9 @@ namespace HlidacStatu.Util.WebShot
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
-        }
+			// TODO: uncomment the following line if the finalizer is overridden above.
+			GC.SuppressFinalize(this);
+		}
         #endregion
     }
 


### PR DESCRIPTION
Invoice.Partial.cs - lepší ochrana, kdyby dotaz do DbEntities padnul, aby došlo na Dispose.

Util.WebShot/Chrome.cs+Worker.cs - Dalo by se úspěšně pochybovat, jestli jsou to přímo unmanaged resources a má smysl vůbec mít Finalize (destructor), když WebDriver je IDisposable, ale bůh ví, jak je ta implementace WebDriveru spolehlivá, takže jsem oživil alespoň GC.SuppressFinalize(), když už se Dispose() zavolá explicitně.