### PR TITLE
chybka v popisu typu

### DIFF
--- a/Lib/Data/External/DataSets/Dataset.Property.cs
+++ b/Lib/Data/External/DataSets/Dataset.Property.cs
@@ -35,7 +35,7 @@ namespace HlidacStatu.Lib.Data.External.DataSets
                     return "datum";
                 if (this.Type == typeof(string)
                     )
-                    return "datum";
+                    return "text";
                 if (this.Type == typeof(Nullable<bool>)
                     || this.Type == typeof(bool)
                     )


### PR DESCRIPTION
napr na https://www.hlidacstatu.cz/data/napoveda/vyjadreni-politiku se skoro u vsech poli pise "datum", vypada to na preklep v Dataset.Property.cs
![image](https://user-images.githubusercontent.com/1639610/102027260-2d113c80-3da3-11eb-86d2-c914b1abbcd4.png)
